### PR TITLE
Don't use :sly-dependencies in contrib definition

### DIFF
--- a/sly-repl-ansi-color.el
+++ b/sly-repl-ansi-color.el
@@ -1,11 +1,11 @@
 ;; Ported from is Max Mikhanosha's code.
 (require 'ansi-color)
+(require 'sly-mrepl)
 
 (define-sly-contrib sly-repl-ansi-color
   "Turn on ANSI colors in the mREPL output"
   (:authors '("Javier Olaechea" "Max Mikhanosha"))
   (:license "GPL")
-  (:sly-dependencies sly-mrepl)
   (:on-load (progn
               (sly-repl-ansi-on)
               (add-hook 'sly-mrepl-output-filter-functions


### PR DESCRIPTION
Regular `require' should be used. SLY will warn and possibly
forbid this idiom in the future.
- sly-repl-ansi-color.el (define-sly-contrib): kill sly-dependencies
