### PR TITLE
Only require sly and not sly-mrepl

### DIFF
--- a/sly-repl-ansi-color.el
+++ b/sly-repl-ansi-color.el
@@ -13,7 +13,7 @@
 
 ;;; Code:
 (require 'ansi-color)
-(require 'sly-mrepl)
+(require 'sly)
 
 (define-sly-contrib sly-repl-ansi-color
   "Turn on ANSI colors in the mREPL output"


### PR DESCRIPTION
The reason I'm making this pull request is because `(require 'sly-mrepl)` will error when capitaomorte/sly#79 happens.

I don't think `sly-repl-ansi-color` actually needs anything from `sly-mrepl` (please correct me if I'm wrong). Even if you ended up  running `add-hook` for `sly-mrepl-output-filter-functions` before it even existed, everything should still work fine. I wasn't able to find any problems when testing this.
